### PR TITLE
Update logback auf 1.2.10 wegen CVE-2021-42550

### DIFF
--- a/java/byps/build.gradle
+++ b/java/byps/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 	compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
 	// BYPS-16: Support basic configuration of logback and log4j. Byps requires one of 
 	// these frameworks only if you explicitly instruct it to do logging of its own.
-	compileOnly group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+	compileOnly group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.10'
 	compileOnly group: 'log4j', name: 'log4j', version: '1.2.17'
 	
 	// https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api

--- a/java/bypsgen/build.gradle
+++ b/java/bypsgen/build.gradle
@@ -61,7 +61,7 @@ dependencies {
   compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
   compile group: 'org.slf4j', name: 'jcl-over-slf4j', version: '1.7.30'
   
-	compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
+	compile group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.10'
 
 	// https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-models
 	compile group: 'io.swagger.core.v3', name: 'swagger-models', version: '2.1.7'


### PR DESCRIPTION
Logback auf 1.2.10 updaten wegen CVE