### PR TITLE
BYPS-93: Fix code generation failing when no output file is present.

### DIFF
--- a/java/bypsgen/src/byps/gen/ts/GeneratorTS.java
+++ b/java/bypsgen/src/byps/gen/ts/GeneratorTS.java
@@ -38,7 +38,7 @@ public class GeneratorTS implements Generator {
 		PrintContext printContext = DependencyContainer.get(PrintContext.class);
 		GenerationFilters generationFilters = DependencyContainer.get(GenerationFilters.class);
 
-		if (!printContext.destFile.delete()) {
+		if (printContext.destFile.exists() && !printContext.destFile.delete()) {
 			throw new IOException("Couldn't delete destFile");
 		}
 


### PR DESCRIPTION
The TS Generator currently refuses to build if there was no output file present. This fixes that behaviour